### PR TITLE
Minor fix hockeyApp.js

### DIFF
--- a/hockeyApp.js
+++ b/hockeyApp.js
@@ -35,7 +35,7 @@ var tags = tl.getInput("tags", /*required=*/ false);
 var teams = tl.getInput("teams", /*required=*/ false);
 var users = tl.getInput("users", /*required=*/ false);
 
-binaryPath = checkAndFixFilePath(binaryPath, "symbolsPath");
+binaryPath = checkAndFixFilePath(binaryPath, "binaryPath");
 symbolsPath = checkAndFixFilePath(symbolsPath, "symbolsPath");
 nativeLibraryPath = checkAndFixFilePath(nativeLibraryPath, "nativeLibraryPath");
 notesPath = checkAndFixFilePath(notesPath, "notesPath");


### PR DESCRIPTION
Fixed misprint in line 38, must be "binaryPath" instead of "symbolsPath". Old version gives misleading error notification in the TFS logs in case if path was wrong.